### PR TITLE
Pass any provided className through to container div

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: node_js
+node_js:
+  - "node"
+cache:
+  directories:
+    - "node_modules"
+script:
+- npm run lint
+- npm test

--- a/README.md
+++ b/README.md
@@ -60,16 +60,16 @@ npm install --save react react-dom
 Import the container element into your React component:
 
 ```js
-import SocialEmbedContainer from 'react-oembed-container';
+import EmbedContainer from 'react-oembed-container';
 ```
-(or another name such as `OEmbedContainer` if you prefer; this README choses to sidestep the irreconcilable conflict between oEmbed's use of a lowercase "o" and React components' traditionally uppercase identifiers.)
 
 Then use this container to wrap whatever JSX you would normally use to render the content:
+
 ```js
 render() {
   const { post } = this.props;
   return (
-    <SocialEmbedContainer markup={post.content.rendered}>
+    <EmbedContainer markup={post.content.rendered}>
 
       {/* for example, */}
       <article id={`post-${post.id}`}>
@@ -77,9 +77,29 @@ render() {
         <div dangerouslySetInnerHTML={{ __html: post.content.rendered }} />
       </article>
 
-    </SocialEmbedContainer>
+    </EmbedContainer>
   );
 }
+```
+
+If you set a `className` on the `EmbedContainer` component, that class will be passed through to the rendered `<div>` container:
+
+```js
+render() {
+  const { post } = this.props;
+  return (
+    <EmbedContainer
+      className="article-content"
+      markup={post.content.rendered}
+    >
+      <p>Article text here</p>
+    </EmbedContainer>
+  );
+}
+```
+yields
+```html
+<div class="article-content"><p>Article text here</p></div>
 ```
 
 ## Local Development

--- a/src/index.js
+++ b/src/index.js
@@ -34,22 +34,34 @@ class EmbedContainer extends Component {
   }
 
   render() {
-    const { children, markup } = this.props;
+    const {
+      children,
+      className,
+      markup,
+    } = this.props;
     markup.split(' ').join(' ');
     return (
-      <div ref={(node) => { this.container = node; }}>
+      <div
+        className={className}
+        ref={(node) => { this.container = node; }}
+      >
         {children}
       </div>
     );
   }
 }
 
+EmbedContainer.defaultProps = {
+  className: null,
+};
+
 EmbedContainer.propTypes = {
-  markup: PropTypes.string.isRequired,
   children: PropTypes.oneOfType([
     PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
   ]).isRequired,
+  className: PropTypes.string,
+  markup: PropTypes.string.isRequired,
 };
 
 export default EmbedContainer;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -22,6 +22,15 @@ describe('Social Embed Container', () => {
     expect(container.html()).toBe('<div>String <code>HTML</code> Content</div>');
   });
 
+  it('Should pass through any provided className', () => {
+    const container = mount((
+      <EmbedContainer markup="String <code>HTML</code> Content" className="test classes">
+        String <code>HTML</code> Content
+      </EmbedContainer>
+    ));
+    expect(container.html()).toBe('<div class="test classes">String <code>HTML</code> Content</div>');
+  });
+
   it('should enqueue any detected script tag', () => {
     mount((
       <EmbedContainer markup={`


### PR DESCRIPTION
If a `className` is set on the EmbedContainer, pass it through to the rendered container `<div>`. This can reduce DOM nesting in certain situations.

Fixes #2, and removes my sleepily-penned digression about component naming from the docs.