### PR TITLE
Add a test case for twitch.tv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.4.0 
 
 - Added support for Trello [#14](https://github.com/humanmade/react-oembed-container/pull/14) (You may use [this plugin](https://github.com/humanmade/trello-embeds) to enable Trello card embeds on your WordPress site)
+- Added a test case for Twitch.tv [#16](https://github.com/humanmade/react-oembed-container/pull/16)
 - Removed CollegeHumor test cases (RIP) [#15](https://github.com/humanmade/react-oembed-container/pull/15)
 - Added [docs website](https://humanmade.github.io/react-oembed-container)
 - Update Twitter embed `isLoaded` check to fix undefined reference issue, props @ghankerson [#10](https://github.com/humanmade/react-oembed-container/pull/10), [#11](https://github.com/humanmade/react-oembed-container/pull/11)

--- a/stories/index.stories.js
+++ b/stories/index.stories.js
@@ -33,4 +33,5 @@ storiesOf( 'EmbedContainer', module )
 	.add( 'WordPress.tv', () => testEmbedContainerWith( fixtures.wordpresstv ) )
 	.add( 'Issuu', () => testEmbedContainerWith( fixtures.issuu ) )
 	.add( 'Flickr', () => testEmbedContainerWith( fixtures.flickr ) )
-	.add( 'Trello', () => testEmbedContainerWith( fixtures.trello ) );
+	.add( 'Trello', () => testEmbedContainerWith( fixtures.trello ) )
+	.add( 'Twitch', () => testEmbedContainerWith( fixtures.twitch ) );

--- a/test/fixtures.js
+++ b/test/fixtures.js
@@ -168,6 +168,12 @@ export const trello = `<h2>Trello</h2>
 <script src="https://p.trellocdn.com/embed.min.js"></script>
 `;
 
+export const twitch = `<h2>Twitch</h2>
+
+<iframe src="https://player.twitch.tv/?channel=boilerroom" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620"></iframe>
+<a href="https://www.twitch.tv/boilerroom?tt_content=text_link&tt_medium=live_embed" style="padding:2px 0px 4px; display:block; width:345px; font-weight:normal; font-size:10px; text-decoration:underline;">Watch live video from BoilerRoom on www.twitch.tv</a>
+`;
+
 export const all = [
 	facebook,
 	twitter,
@@ -187,4 +193,5 @@ export const all = [
 	issuu,
 	flickr,
 	trello,
+	twitch,
 ].join( '\n\n' );


### PR DESCRIPTION
Not necessarily supported within WP, but it's an iFrame embed and has been more prominent than usual of late given how everything's now remote, so may as well make sure we support it!