### PR TITLE
Update react and react-dom peerDependencies values

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "browserslist": "> 0.25%, not dead",
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0"
+    "react": "^16.2.0 || ^17.0.0",
+    "react-dom": "^16.2.0 || ^17.0.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0"


### PR DESCRIPTION
Updating these values should prevent a peerDependencies error from occurring.
When NPM installing with v7+ to a repo that also has `react@17.0.0` or higher in its `package.json` as a dependency.