### PR TITLE
chore: update peerDependencies to support React 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,8 +41,8 @@
   },
   "browserslist": "> 0.25%, not dead",
   "peerDependencies": {
-    "react": "^16.2.0 || ^17.0.0",
-    "react-dom": "^16.2.0 || ^17.0.0"
+    "react": "^16.2.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.2.0 || ^17.0.0 || ^18.0.0"
   },
   "dependencies": {
     "prop-types": "^15.6.0"


### PR DESCRIPTION
This PR updates `package.json` by adding React 18 in order to avoid peer dependencies conflicts on projects using React 18.